### PR TITLE
feat: allow extend App, Page, Component, Behavior

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # npm
 node_modules
 package-lock.json
+yarn.lock
 
 # OS X
 .DS_Store*

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -41,3 +41,5 @@ App({
 
 // $ExpectType Instance<Record<string, any>>
 getApp()
+
+App.Page = () => {}

--- a/test/behavior.test.ts
+++ b/test/behavior.test.ts
@@ -37,3 +37,5 @@ Behavior({
     },
   },
 })
+
+Behavior.a = () => {}

--- a/test/component.test.ts
+++ b/test/component.test.ts
@@ -245,3 +245,5 @@ Component({
     },
   },
 })
+
+Component.a = () => {}

--- a/test/page.test.ts
+++ b/test/page.test.ts
@@ -197,3 +197,5 @@ Page<DataType, CustomOption>({
     this.data.logs // $ExpectType string[]
   },
 })
+
+Page.a = () => {}

--- a/types/wx/lib.wx.app.d.ts
+++ b/types/wx/lib.wx.app.d.ts
@@ -227,7 +227,7 @@ declare namespace WechatMiniprogram {
             ThisType<Instance<T>>
         type TrivialInstance = Instance<IAnyObject>
 
-        interface Constructor {
+        interface Constructor extends IAnyObject {
             <T extends IAnyObject>(options: Options<T>): void
         }
 

--- a/types/wx/lib.wx.behavior.d.ts
+++ b/types/wx/lib.wx.behavior.d.ts
@@ -27,7 +27,7 @@ declare namespace WechatMiniprogram {
             Partial<OtherOption> &
             Partial<Lifetimes> &
             ThisType<Instance<TData, TProperty, TMethod>>
-        interface Constructor {
+        interface Constructor extends IAnyObject {
             <
                 TData extends DataOption,
                 TProperty extends PropertyOption,

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -34,7 +34,7 @@ declare namespace WechatMiniprogram {
             Partial<OtherOption> &
             Partial<Lifetimes> &
             ThisType<Instance<TData, TProperty, TMethod>>
-        interface Constructor {
+        interface Constructor extends IAnyObject {
             <
                 TData extends DataOption,
                 TProperty extends PropertyOption,

--- a/types/wx/lib.wx.page.d.ts
+++ b/types/wx/lib.wx.page.d.ts
@@ -24,7 +24,7 @@ declare namespace WechatMiniprogram {
         > = (TCustom & Partial<Data<TData>> & Partial<ILifetime>) &
             ThisType<Instance<TData, TCustom>>
         type TrivialInstance = Instance<IAnyObject, IAnyObject>
-        interface Constructor {
+        interface Constructor extends IAnyObject {
             <TData extends DataOption, TCustom extends CustomOption>(
                 options: Options<TData, TCustom>,
             ): void


### PR DESCRIPTION
在实际开发中，小程序暴露的一些方法是可以进行扩展的，比如在App上增加一些全局属性或全局方法，从而可以在所有页面中获取到。

目前的定义不支持扩展，所以希望可以允许扩展，PR中只对常用的App, Page, Component, Behavior做了修改，且增加了测试。