### PR TITLE
feat(page): 暴露 page 的 options

### DIFF
--- a/types/wx/lib.wx.page.d.ts
+++ b/types/wx/lib.wx.page.d.ts
@@ -127,6 +127,9 @@ declare namespace WechatMiniprogram {
 
             /** 到当前页面的路径 */
             route: string
+            
+            /** 打开当前页面路径中的参数 */
+            options: Record<string, string | undefined>
         }
 
         type DataOption = Record<string, any>


### PR DESCRIPTION
Page 构造器的 `this` 上是有一个 `options` 参数的，等同于 onLoad 时获取的 options