### PR TITLE
fix(component): getOpenerEventChannel

### DIFF
--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -242,6 +242,8 @@ declare namespace WechatMiniprogram {
                 options: ClearAnimationOptions,
                 callback: () => void,
             ): void
+
+            getOpenerEventChannel(): EventChannel
         }
 
         interface ComponentOptions {


### PR DESCRIPTION
使用 Component 构造器构造页面时 无法调用 getOpenerEventChannel