### PR TITLE
feat(component): extends page lifetime

### DIFF
--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -57,7 +57,7 @@ declare namespace WechatMiniprogram {
         }
         type DataOption = Record<string, any>
         type PropertyOption = Record<string, AllProperty>
-        type MethodOption = Record<string, (...args: any[]) => any>
+        type MethodOption = Record<string, (...args: any[]) => any> & Partial<Page.ILifetime>
 
         interface Data<D extends DataOption> {
             /** 组件的内部数据，和 `properties` 一同用于组件的模板渲染 */


### PR DESCRIPTION
根据文档 [使用 Component 构造器构造页面](https://developers.weixin.qq.com/miniprogram/dev/framework/custom-component/component.html#%E4%BD%BF%E7%94%A8-Component-%E6%9E%84%E9%80%A0%E5%99%A8%E6%9E%84%E9%80%A0%E9%A1%B5%E9%9D%A2) 使用 `Component` 作为页面时，应把生命周期函数放在 `methods` 下