### PR TITLE
修复 Animation.export() 返回值类型错误

### DIFF
--- a/types/wx/lib.wx.api.d.ts
+++ b/types/wx/lib.wx.api.d.ts
@@ -5504,7 +5504,9 @@ innerAudioContext.onError((res) => {
         /** [Array.&lt;Object&gt; Animation.export()](https://developers.weixin.qq.com/miniprogram/dev/api/ui/animation/Animation.export.html)
          *
          * 导出动画队列。**export 方法每次调用后会清掉之前的动画操作。** */
-        export(): IAnyObject[]
+        export(): {
+            actions: IAnyObject[]
+        }
         /** [[Animation](https://developers.weixin.qq.com/miniprogram/dev/api/ui/animation/Animation.html) Animation.backgroundColor(string value)](https://developers.weixin.qq.com/miniprogram/dev/api/ui/animation/Animation.backgroundColor.html)
          *
          * 设置背景色 */


### PR DESCRIPTION
Animation.export() 的返回值是一个包含 actions 字段的对象

![image](https://user-images.githubusercontent.com/3471836/79629926-df92f000-817f-11ea-9e0d-65d487d4a105.png)
