### PR TITLE
doc: add jsconfig guide

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -33,6 +33,10 @@ Or specify types in typescript config:
 
 - Specify `types: ["miniprogram-api-typings"]` in `tsconfig.json`
 
+Or specify types in js config:
+
+- Specify `typeRoots: ["miniprogram-api-typings"]` in `jsconfig.json`
+
 Or reference by [Triple-Slash Directives](https://www.typescriptlang.org/docs/handbook/triple-slash-directives.html):
 
 - `/// <reference path="node_modules/miniprogram-api-typings/index.d.ts" />`

--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ npm install miniprogram-api-typings
 
 - 在 `tsconfig.json` 中指定 `types: ["miniprogram-api-typings"]`
 
+或者在 js 配置中指定：
+
+- 在 `jsconfig.json` 中指定 `typeRoots: ["miniprogram-api-typings"]`
+
 或者通过 [三斜杠指令](https://www.tslang.cn/docs/handbook/triple-slash-directives.html) 引用：
 
 - `/// <reference path="node_modules/miniprogram-api-typings/index.d.ts" />`


### PR DESCRIPTION
PR描述：

当前readme说明中缺少了jsconfig的配置说明，此PR进行了补充