### PR TITLE
feat: 新增 component 的 properties 可以 as 类型推断

### DIFF
--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -103,6 +103,7 @@ declare namespace WechatMiniprogram.Component {
         | BooleanConstructor
         | ArrayConstructor
         | ObjectConstructor
+        | unknown
         | null
     type ValueType<T extends PropertyType> = T extends null
         ? any
@@ -116,6 +117,8 @@ declare namespace WechatMiniprogram.Component {
         ? any[]
         : T extends ObjectConstructor
         ? IAnyObject
+        : T extends unknown
+        ? T
         : never
     type FullProperty<T extends PropertyType> = {
         /** 属性类型 */
@@ -139,6 +142,7 @@ declare namespace WechatMiniprogram.Component {
         | FullProperty<BooleanConstructor>
         | FullProperty<ArrayConstructor>
         | FullProperty<ObjectConstructor>
+        | FullProperty<unknown>
         | FullProperty<null>
     type ShortProperty =
         | StringConstructor


### PR DESCRIPTION
以下为实例代码
（小程序代码片段不支持TS）

[小程序组件 properties 类型推断.zip](https://github.com/wechat-miniprogram/api-typings/files/12645950/properties.zip)

核心代码
<img width="742" alt="image" src="https://github.com/wechat-miniprogram/api-typings/assets/8382136/c9203b6a-71aa-4237-9f99-3a44054068b9">
