### PR TITLE
fix: there is no correct ref for properties in this.setData

### DIFF
--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -28,7 +28,7 @@ declare namespace WechatMiniprogram.Component {
         TCustomInstanceProperty extends IAnyObject = {},
         TIsPage extends boolean = false
     > = InstanceProperties &
-        InstanceMethods<TData> &
+        InstanceMethods<TData & PropertyOptionToData<TProperty>> &
         TMethod &
         (TIsPage extends true ? Page.ILifetime : {}) &
         TCustomInstanceProperty & {


### PR DESCRIPTION
You can get ref from this.setData({ keyA }) where keyA is a key of data, but when it is property, it can not be.