### PR TITLE
feat: supports the issues/331 mentioned in points 2, 3, 4

### DIFF
--- a/test/component.test.ts
+++ b/test/component.test.ts
@@ -120,6 +120,17 @@ Component({
   },
 })
 
+expectError(
+  Component({
+    custom: 1,
+    methods: {
+      f() {
+        this.custom
+      },
+    },
+  }),
+)
+
 interface Config {
   a: number
 }

--- a/test/component.test.ts
+++ b/test/component.test.ts
@@ -29,7 +29,7 @@ Component({
     max: {
       type: Number,
       value: 0,
-      observer(newVal, oldVal) {
+      observer(newVal: number, oldVal: number) {
         expectType<number>(newVal)
         expectType<number>(oldVal)
         expectType<void>(this.onMyButtonTap())
@@ -120,17 +120,6 @@ Component({
   },
 })
 
-expectError(
-  Component({
-    custom: 1,
-    methods: {
-      f() {
-        this.custom
-      },
-    },
-  }),
-)
-
 interface Config {
   a: number
 }
@@ -178,7 +167,7 @@ Component({
       expectType<number>(this.data.n2)
       expectType<string>(this.data.s)
       expectType<any[]>(this.data.a)
-      expectType<any[]>(this.data.a2)
+      expectType<number[]>(this.data.a2)
       expectType<boolean>(this.data.b)
       expectType<Record<string, any>>(this.data.o)
       expectType<any>(this.data.a[0])
@@ -218,7 +207,7 @@ Component({
       expectType<number>(this.data.n2)
       expectType<string>(this.data.s)
       expectType<any[]>(this.data.a)
-      expectType<any[]>(this.data.a2)
+      expectType<number[]>(this.data.a2)
       expectType<boolean>(this.data.b)
       expectType<Record<string, any>>(this.data.o)
       expectType<Record<string, any>>(this.data.o2)
@@ -243,7 +232,7 @@ Component({
   methods: {
     f() {
       expectType<number>(this.data.n)
-      expectType<any[]>(this.data.a)
+      expectType<number[]>(this.data.a)
     },
   },
 })

--- a/test/component.test.ts
+++ b/test/component.test.ts
@@ -29,7 +29,7 @@ Component({
     max: {
       type: Number,
       value: 0,
-      observer(newVal: number, oldVal: number) {
+      observer(newVal, oldVal) {
         expectType<number>(newVal)
         expectType<number>(oldVal)
         expectType<void>(this.onMyButtonTap())

--- a/test/issue.test.ts
+++ b/test/issue.test.ts
@@ -397,7 +397,9 @@ import WX = WechatMiniprogram
         return this.data.foo
       },
       test() {
-        expectType<Record<string, any>>(this.data.bar)
+        expectType<{
+          skuNum: number
+      }>(this.data.bar)
         expectType<number>(this.getDataOrPoperty())
       },
     }

--- a/test/issue.test.ts
+++ b/test/issue.test.ts
@@ -464,7 +464,6 @@ import WX = WechatMiniprogram
   }
 
   Component({
-    _timer: '',
     properties: {
       bar: {
         type: Object,
@@ -483,7 +482,6 @@ import WX = WechatMiniprogram
       test() {
         expectType<Foo>(this.data.bar)
         expectType<Foo[]>(this.getData())
-        expectType<string>(this._timer)
       },
     }
   })

--- a/test/issue.test.ts
+++ b/test/issue.test.ts
@@ -1,4 +1,4 @@
-import { expectType } from 'tsd'
+import { expectError, expectType } from 'tsd'
 
 // https://github.com/wechat-miniprogram/api-typings/issues/11
 expectType<string>(wx.env.USER_DATA_PATH)
@@ -442,4 +442,49 @@ import WX = WechatMiniprogram
   const offscreenCanvas = wx.createOffscreenCanvas(800, 600)
   expectType<number>(offscreenCanvas.height)
   expectType<number>(offscreenCanvas.width)
+}
+
+// https://github.com/wechat-miniprogram/api-typings/issues/332
+{
+  Component({
+    data: {
+      a: ''
+    },
+    methods: {
+      test() {
+        expectError<any>(this.data.xxx)
+      },
+    }
+  })
+}
+
+{
+  interface Foo {
+    f: string
+  }
+
+  Component({
+    _timer: '',
+    properties: {
+      bar: {
+        type: Object,
+        value: { f: '' } as Foo,
+        observer () {}
+      },
+      foo: {
+        type: Array,
+        value: [] as Foo[],
+      }
+    },
+    methods: {
+      getData() {
+        return this.data.foo
+      },
+      test() {
+        expectType<Foo>(this.data.bar)
+        expectType<Foo[]>(this.getData())
+        expectType<string>(this._timer)
+      },
+    }
+  })
 }

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -70,7 +70,7 @@ declare namespace WechatMiniprogram.Component {
         <
             TData extends DataOption,
             // 给泛型默认值，避免出现当组件无 properties 选项时
-            // 当xxx未在 data 中声明，this.data.xxx 为 any 的问题。
+            // 当xxx未在 data 中声明，this.data.xxx 为 any 且不报 TS2339 error 的问题。
             TProperty extends PropertyOption = {},
             TMethod extends MethodOption = {},
             TCustomInstanceProperty extends IAnyObject = {},

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -56,8 +56,6 @@ declare namespace WechatMiniprogram.Component {
         Partial<Method<TMethod, TIsPage>> &
         Partial<OtherOption> &
         Partial<Lifetimes> &
-        // 有很大几率会在 this.xxx 上使用一些暂存的变量，应该像Page一样支持传入自定义属性
-        Partial<TCustomInstanceProperty> &
         ThisType<
             Instance<
                 TData,

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -21,6 +21,7 @@ SOFTWARE.
 ***************************************************************************** */
 
 declare namespace WechatMiniprogram.Component {
+    type FilterUnknownProperty<TProperty> = string extends keyof TProperty ? {} : TProperty
     type Instance<
         TData extends DataOption,
         TProperty extends PropertyOption,
@@ -33,9 +34,9 @@ declare namespace WechatMiniprogram.Component {
         (TIsPage extends true ? Page.ILifetime : {}) &
         TCustomInstanceProperty & {
             /** 组件数据，**包括内部数据和属性值** */
-            data: TData & PropertyOptionToData<TProperty>
+            data: TData & PropertyOptionToData<FilterUnknownProperty<TProperty>>
             /** 组件数据，**包括内部数据和属性值**（与 `data` 一致） */
-            properties: TData & PropertyOptionToData<TProperty>
+            properties: TData & PropertyOptionToData<FilterUnknownProperty<TProperty>>
         }
     type TrivialInstance = Instance<
         IAnyObject,
@@ -69,10 +70,8 @@ declare namespace WechatMiniprogram.Component {
     interface Constructor {
         <
             TData extends DataOption,
-            // 给泛型默认值，避免出现当组件无 properties 选项时
-            // 当xxx未在 data 中声明，this.data.xxx 为 any 且不报 TS2339 error 的问题。
-            TProperty extends PropertyOption = {},
-            TMethod extends MethodOption = {},
+            TProperty extends PropertyOption,
+            TMethod extends MethodOption,
             TCustomInstanceProperty extends IAnyObject = {},
             TIsPage extends boolean = false
         >(

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -153,7 +153,6 @@ declare namespace WechatMiniprogram.Component {
         ? ValueType<T>
         : FullPropertyToData<Exclude<T, ShortProperty>>
     type ArrayOrObject = ArrayConstructor | ObjectConstructor
-    // 支持 Array、Object 的 property 通过 value as ValueType 的方式明确 property 的类型
     type FullPropertyToData<T extends AllFullProperty> = T['type'] extends ArrayOrObject ? unknown extends T['value'] ? ValueType<T['type']> : T['value'] : ValueType<T['type']>
     type PropertyOptionToData<P extends PropertyOption> = {
         [name in keyof P]: PropertyToData<P[name]>


### PR DESCRIPTION
1. Component Object、Array 的 property支持通过 as 明确指定property的类型
2. 支持Component 传自定义属性
3. Component 当组件无 properties 选项时，xxx未在 data 中声明，this.data.xxx 不报 TS2339 error 的问题