### PR TITLE
fix(behavior类型支持迭代)：修复behavior中不包含data/properties时，会导致Component this.data/this.properties上访问未定义属性不抛错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "miniprogram-api-typings",
-  "version": "3.12.3",
+  "name": "@mtypes/miniprogram-api-typings",
+  "version": "4.0.0",
   "description": "Type definitions for APIs of Wechat Mini Program in TypeScript",
   "main": "./index.d.ts",
   "types": "./index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@mtypes/miniprogram-api-typings",
-  "version": "4.0.0",
+  "name": "miniprogram-api-typings",
+  "version": "3.12.3",
   "description": "Type definitions for APIs of Wechat Mini Program in TypeScript",
   "main": "./index.d.ts",
   "types": "./index.d.ts",

--- a/test/issue.test.ts
+++ b/test/issue.test.ts
@@ -599,3 +599,39 @@ import WX = WechatMiniprogram
     }
   })
 }
+
+{
+  const b1 = Behavior({
+    methods: {
+      methodA() {
+        return ['']
+      },
+    },
+  })
+  const b2 = Behavior({
+    properties: {
+      pB: {
+        type: Array,
+        value: [] as string[],
+      }
+    }
+  })
+  const b3 = Behavior({
+    data: {
+      dataC: 'init data',
+    }
+  })
+
+  Component({
+    behaviors: [b1, b2, b3],
+    methods: {
+      test() {
+        expectType<string[]>(this.data.pB)
+        expectType<string>(this.data.dataC)
+        expectType<string[]>(this.methodA())
+        expectError(this.data.xxx)
+        expectError(this.properties.yyy)
+      },
+    }
+  })
+}

--- a/types/wx/lib.wx.behavior.d.ts
+++ b/types/wx/lib.wx.behavior.d.ts
@@ -29,9 +29,9 @@ declare namespace WechatMiniprogram.Behavior {
         TBehavior extends BehaviorOption = []
     > = string & {
         [key in 'BehaviorType']?: {
-            data: Component.FilterUnknownProperty<TData> & Component.MixinData<TBehavior>
-            properties: Component.FilterUnknownProperty<TProperty> & Component.MixinProperties<TBehavior, true>
-            methods: Component.FilterUnknownProperty<TMethod> & Component.MixinMethods<TBehavior>
+            data: Component.FilterUnknownType<TData> & Component.MixinData<TBehavior>
+            properties: Component.FilterUnknownType<TProperty> & Component.MixinProperties<TBehavior, true>
+            methods: Component.FilterUnknownType<TMethod> & Component.MixinMethods<TBehavior>
         }
     }
     type Instance<

--- a/types/wx/lib.wx.behavior.d.ts
+++ b/types/wx/lib.wx.behavior.d.ts
@@ -29,9 +29,9 @@ declare namespace WechatMiniprogram.Behavior {
         TBehavior extends BehaviorOption = []
     > = string & {
         [key in 'BehaviorType']?: {
-            data: TData & Component.MixinData<TBehavior>
-            properties: TProperty & Component.MixinProperties<TBehavior, true>
-            methods: TMethod & Component.MixinMethods<TBehavior>
+            data: Component.FilterUnknownProperty<TData> & Component.MixinData<TBehavior>
+            properties: Component.FilterUnknownProperty<TProperty> & Component.MixinProperties<TBehavior, true>
+            methods: Component.FilterUnknownProperty<TMethod> & Component.MixinMethods<TBehavior>
         }
     }
     type Instance<

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -21,7 +21,7 @@ SOFTWARE.
 ***************************************************************************** */
 
 declare namespace WechatMiniprogram.Component {
-    type FilterUnknownProperty<TProperty> = string extends keyof TProperty ? {} : TProperty
+    type FilterUnknownType<T> = string extends keyof T ? {} : T
     type Instance<
         TData extends DataOption,
         TProperty extends PropertyOption,
@@ -36,11 +36,11 @@ declare namespace WechatMiniprogram.Component {
         (TIsPage extends true ? Page.ILifetime : {}) &
         Omit<TCustomInstanceProperty, 'properties' | 'methods' | 'data'> & {
             /** 组件数据，**包括内部数据和属性值** */
-            data: FilterUnknownProperty<TData> & MixinData<TBehavior> &
-            MixinProperties<TBehavior> & PropertyOptionToData<FilterUnknownProperty<TProperty>>
+            data: FilterUnknownType<TData> & MixinData<TBehavior> &
+            MixinProperties<TBehavior> & PropertyOptionToData<FilterUnknownType<TProperty>>
             /** 组件数据，**包括内部数据和属性值**（与 `data` 一致） */
-            properties: FilterUnknownProperty<TData> & MixinData<TBehavior> &
-            MixinProperties<TBehavior> & PropertyOptionToData<FilterUnknownProperty<TProperty>>
+            properties: FilterUnknownType<TData> & MixinData<TBehavior> &
+            MixinProperties<TBehavior> & PropertyOptionToData<FilterUnknownType<TProperty>>
         }
 
     type IEmptyArray = []

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -36,10 +36,10 @@ declare namespace WechatMiniprogram.Component {
         (TIsPage extends true ? Page.ILifetime : {}) &
         Omit<TCustomInstanceProperty, 'properties' | 'methods' | 'data'> & {
             /** 组件数据，**包括内部数据和属性值** */
-            data: TData & MixinData<TBehavior> &
+            data: FilterUnknownProperty<TData> & MixinData<TBehavior> &
             MixinProperties<TBehavior> & PropertyOptionToData<FilterUnknownProperty<TProperty>>
             /** 组件数据，**包括内部数据和属性值**（与 `data` 一致） */
-            properties: TData & MixinData<TBehavior> &
+            properties: FilterUnknownProperty<TData> & MixinData<TBehavior> &
             MixinProperties<TBehavior> & PropertyOptionToData<FilterUnknownProperty<TProperty>>
         }
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ce4c8be2-0ae2-4c29-9a79-f024984305b6)
