### PR TITLE
feat: prioritize inferring property type from value

### DIFF
--- a/test/issue.test.ts
+++ b/test/issue.test.ts
@@ -467,6 +467,22 @@ import WX = WechatMiniprogram
 
   Component({
     properties: {
+      any: {
+        type: null,
+        value: '',
+      },
+      num: {
+        type: Number,
+        value: 0 as 0 | 1,
+      },
+      str: {
+        type: String,
+        value: 'A' as 'A' | 'B',
+      },
+      bool: {
+        type: Boolean,
+        value: false,
+      },
       bar: {
         type: Object,
         value: { f: '' } as Foo,
@@ -475,16 +491,24 @@ import WX = WechatMiniprogram
       foo: {
         type: Array,
         value: [] as Foo[],
-      }
+      },
+      noValue: {
+        type: String,
+      },
     },
     methods: {
       getData() {
         return this.data.foo
       },
       test() {
+        expectType<any>(this.data.any)
+        expectType<0 | 1>(this.data.num)
+        expectType<'A' | 'B'>(this.data.str)
+        expectType<boolean>(this.data.bool)
         expectType<Foo>(this.data.bar)
         expectType<Foo>(this.properties.bar)
         expectType<Foo[]>(this.getData())
+        expectType<string>(this.data.noValue)
       },
     }
   })

--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -180,8 +180,7 @@ declare namespace WechatMiniprogram.Component {
     type PropertyToData<T extends AllProperty> = T extends ShortProperty
         ? ValueType<T>
         : FullPropertyToData<Exclude<T, ShortProperty>>
-    type ArrayOrObject = ArrayConstructor | ObjectConstructor
-    type FullPropertyToData<T extends AllFullProperty> = T['type'] extends ArrayOrObject ? unknown extends T['value'] ? ValueType<T['type']> : T['value'] : ValueType<T['type']>
+    type FullPropertyToData<T extends AllFullProperty> = T['type'] extends null | BooleanConstructor ? ValueType<T['type']> : unknown extends T['value'] ? ValueType<T['type']> : T['value']
     type PropertyOptionToData<P extends PropertyOption> = {
         [name in keyof P]: PropertyToData<P[name]>
     }


### PR DESCRIPTION
参考：https://github.com/wechat-miniprogram/api-typings/pull/332#issuecomment-2393080969

`boolean` 类型不能优先从 value 推导，否则推导出来的类型是 `true` 或者 `false`，而非 `boolean`