### PR TITLE
feat: 优化FilterUnknownType工具类

### DIFF
--- a/types/wx/lib.wx.component.d.ts
+++ b/types/wx/lib.wx.component.d.ts
@@ -21,7 +21,9 @@ SOFTWARE.
 ***************************************************************************** */
 
 declare namespace WechatMiniprogram.Component {
-    type FilterUnknownType<T> = string extends keyof T ? {} : T
+    type FilterUnknownType<T> = {
+        [P in keyof T]: string extends P ? never : T[P]
+    }
     type Instance<
         TData extends DataOption,
         TProperty extends PropertyOption,


### PR DESCRIPTION
## 改进 `FilterUnknownType<T>` 类型定义的精确性

### 🔍 问题描述

原来的 `FilterUnknownType<T>` 实现过于粗暴：

```typescript
type FilterUnknownType<T> = string extends keyof T ? {} : T
```

当类型 `T` 包含字符串索引签名时，会直接返回空对象 `{}`，这导致**所有已知的字面量属性也被过滤掉了**。

### ✨ 解决方案

新的实现更加精确：

```typescript
type FilterUnknownType<T> = {
    [P in keyof T]: string extends P ? never : T[P]
}
```

这个实现会：
1. 遍历类型 `T` 的每个属性键 `P`
2. 对于字符串索引签名（`string extends P` 为 `true`），将其过滤为 `never`
3. 对于具体的字面量属性键，保留原始类型 `T[P]`

### 🎯 改进效果

以一个混合类型为例：

```typescript
type Mixed = { name: string; age: number; [key: string]: any }

// 原实现结果：{}
// 新实现结果：{ name: string; age: number }
```

### 💡 意义

新实现能够**精确地只过滤掉未知的动态属性**，同时**保留所有已知的字面量属性**，这对于微信小程序组件的类型安全更加重要，确保开发者能够正确访问到组件的已知属性，而不会因为存在字符串索引签名就丢失所有类型信息。